### PR TITLE
bump version of url

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "git://github.com/kriskowal/url2.git"
   },
   "dependencies": {
-    "url": ">=0.7.9 <0.8"
+    "url": "0.10.2"
   },
   "devDependencies": {
     "jshint": ">=2.1 <3",


### PR DESCRIPTION
`url@0.7.9` has broken `punycode` in dependencies.
This broken `punycode` contains git submodules in source, which disallow to run `git clean -dfx`

```
fatal: Not a git repository: /Users/Mathias/Projects/punycode.js/.git/modules/vendor/docdown
```
