### PR TITLE
Update dependency on url to 0.10.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "git://github.com/kriskowal/url2.git"
   },
   "dependencies": {
-    "url": ">=0.7.9 <0.8.0"
+    "url": "0.10.2"
   },
   "devDependencies": {
     "jshint": ">=2.1 <3.0.0",


### PR DESCRIPTION
update dependency on `url` to `0.10.2` (matches master branch) to avoid downstream dependency on broken `punycode@1.0.0`
note `url@0.10.3` has your change https://github.com/defunctzombie/node-url/commit/e0a2765246299587ce8f82f5e871fa974c1d63ea but `0.10.2` does not.
resolves #8